### PR TITLE
Allow to call rpush:check twice in the same deployment

### DIFF
--- a/capistrano-rpush.gemspec
+++ b/capistrano-rpush.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_dependency 'capistrano', '~> 3.0', '< 4.0'
-  spec.add_dependency 'rpush', '~> 2.7', '< 3.0'
+  spec.add_dependency 'rpush', '>= 2.7'
 end

--- a/lib/capistrano/tasks/rpush.cap
+++ b/lib/capistrano/tasks/rpush.cap
@@ -48,6 +48,7 @@ namespace :rpush do
         if test "[ -f #{fetch(:rpush_conf)} ]"
           info "using conf file #{fetch(:rpush_conf)}"
         else
+          Rake::Task["rpush:check"].reenable
           invoke 'rpush:check'
         end
         within current_path do


### PR DESCRIPTION
# What

It's now protected in capistrano to call twice the same task:

```
Skipping task `rpush:check'.
Capistrano tasks may only be invoked once. Since task `rpush:check' was previously invoked, invoke("rpush:check") at ruby-2.4.1/gems/capistrano-rpush-0.1.7/lib/capistrano/tasks/rpush.cap:51 will be skipped.
If you really meant to run this task again, first call Rake::Task["rpush:check"].reenable
THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO. Please join the conversation here if this affects you.
https://github.com/capistrano/capistrano/issues/1686
```

