### PR TITLE
Add support for RVM and chruby

### DIFF
--- a/lib/capistrano/rpush.rb
+++ b/lib/capistrano/rpush.rb
@@ -16,6 +16,7 @@ class Capistrano::Rpush < Capistrano::Plugin
     set_if_empty :rpush_log,           -> { File.join(shared_path, 'log', 'rpush.log') }
     set_if_empty :rpush_pid,           -> { File.join(shared_path, 'tmp', 'pids', 'rpush.pid') }
 
+    append :chruby_map_bins, 'rpush'
     append :rbenv_map_bins, 'rpush'
     append :rvm_map_bins, 'rpush'
     append :bundle_bins, 'rpush'

--- a/lib/capistrano/rpush.rb
+++ b/lib/capistrano/rpush.rb
@@ -17,6 +17,7 @@ class Capistrano::Rpush < Capistrano::Plugin
     set_if_empty :rpush_pid,           -> { File.join(shared_path, 'tmp', 'pids', 'rpush.pid') }
 
     append :rbenv_map_bins, 'rpush'
+    append :rvm_map_bins, 'rpush'
     append :bundle_bins, 'rpush'
   end
 


### PR DESCRIPTION
This pull request adds support for the [capistrano/rvm](https://github.com/capistrano/rvm) and [capistrano/chruby](https://github.com/capistrano/chruby) plugins. I don't personally use chruby, but I noticed that both capistrano-sidekiq and capistrano-puma support it (see [here](https://github.com/seuros/capistrano-sidekiq/blob/047a131084fc78364f74615e7ccf3a4833b97c11/lib/capistrano/tasks/sidekiq.rake#L13) and [here](https://github.com/seuros/capistrano-puma/blob/81647bc8402ff1cb485e81d9ec803dfec31aa851/lib/capistrano/puma.rb#L81)), so I went ahead and added it. I have verified that this fixes [the issue](https://github.com/juicyparts/capistrano-rpush/issues/5) that I opened up earlier today.